### PR TITLE
chore: add setting test

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs
@@ -1,0 +1,133 @@
+﻿using MainScripts.DCL.Controllers.SettingsDesktop;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DCL.SettingsCommon
+{
+    public class PlayerPrefsDesktopDisplaySettingsRepositoryShould
+    {
+        [Test]
+        public void GetDataWhenIsAnythingStored()
+        {
+            var storedSettings = new DisplaySettings
+            {
+                vSync = true,
+                windowMode = WindowMode.Borderless,
+                resolutionSizeIndex = 3
+            };
+            var settingsByKey = GivenStoredSettings(storedSettings);
+            var repository = new PlayerPrefsDesktopDisplaySettingsRepository(settingsByKey,
+                GetDefaultDisplaySettings());
+
+            var settings = WhenGetSettings(repository);
+            
+            Assert.AreEqual(storedSettings, settings);
+        }
+
+        [Test]
+        public void GetDefaultSettingsWhenNothingIsStored()
+        {
+            var settingsByKey = GivenNoStoredSettings();
+            var defaultSettings = GetDefaultDisplaySettings();
+            var repository = new PlayerPrefsDesktopDisplaySettingsRepository(settingsByKey,
+                defaultSettings);
+            
+            var settings = WhenGetSettings(repository);
+            
+            Assert.AreEqual(defaultSettings, settings);
+        }
+
+        [Test]
+        public void ApplySettings()
+        {
+            var newSettings = new DisplaySettings
+            {
+                vSync = true,
+                windowMode = WindowMode.Borderless,
+                resolutionSizeIndex = 3
+            };
+            var settingsByKey = GivenNoStoredSettings();
+            var repository = new PlayerPrefsDesktopDisplaySettingsRepository(settingsByKey,
+                GetDefaultDisplaySettings());
+            var onChangedCalled = false;
+            repository.OnChanged += x => onChangedCalled = true;
+            
+            repository.Apply(newSettings);
+            var settings = repository.Data;
+            
+            Assert.AreEqual(newSettings, settings);
+            Assert.IsTrue(onChangedCalled);
+        }
+
+        [Test]
+        public void SaveSettings()
+        {
+            var newSettings = new DisplaySettings
+            {
+                vSync = true,
+                windowMode = WindowMode.Borderless,
+                resolutionSizeIndex = 3
+            };
+            var settingsByKey = GivenNoStoredSettings();
+            var repository = new PlayerPrefsDesktopDisplaySettingsRepository(settingsByKey,
+                GetDefaultDisplaySettings());
+            
+            WhenSettingsAreSaved(repository, newSettings);
+
+            ThenSettingsAreSaved(settingsByKey, newSettings);
+        }
+
+        private DisplaySettings WhenGetSettings(PlayerPrefsDesktopDisplaySettingsRepository repository) =>
+            repository.Data;
+
+        private void WhenSettingsAreSaved(PlayerPrefsDesktopDisplaySettingsRepository repository,
+            DisplaySettings newSettings)
+        {
+            repository.Apply(newSettings);
+            repository.Save();
+        }
+
+        private void ThenSettingsAreSaved(IPlayerPrefsSettingsByKey settingsByKey, DisplaySettings settings)
+        {
+            settingsByKey.Received(1).SetBool(PlayerPrefsDesktopDisplaySettingsRepository.VSYNC, settings.vSync);
+            settingsByKey.Received(1).SetInt(PlayerPrefsDesktopDisplaySettingsRepository.RESOLUTION_SIZE_INDEX,
+                settings.resolutionSizeIndex);
+            settingsByKey.Received(1).SetEnum(PlayerPrefsDesktopDisplaySettingsRepository.WINDOW_MODE,
+                settings.windowMode);
+        }
+
+        private IPlayerPrefsSettingsByKey GivenStoredSettings(DisplaySettings settings)
+        {
+            var settingsByKey = Substitute.For<IPlayerPrefsSettingsByKey>();
+            settingsByKey.GetBool(PlayerPrefsDesktopDisplaySettingsRepository.VSYNC, Arg.Any<bool>())
+                .Returns(settings.vSync);
+            settingsByKey.GetInt(PlayerPrefsDesktopDisplaySettingsRepository.RESOLUTION_SIZE_INDEX, Arg.Any<int>())
+                .Returns(settings.resolutionSizeIndex);
+            settingsByKey.GetEnum(PlayerPrefsDesktopDisplaySettingsRepository.WINDOW_MODE, Arg.Any<WindowMode>())
+                .Returns(settings.windowMode);
+            return settingsByKey;
+        }
+        
+        private IPlayerPrefsSettingsByKey GivenNoStoredSettings()
+        {
+            var settingsByKey = Substitute.For<IPlayerPrefsSettingsByKey>();
+            settingsByKey.GetBool(Arg.Any<string>(), Arg.Any<bool>())
+                .Returns(call => call[1]);
+            settingsByKey.GetInt(Arg.Any<string>(), Arg.Any<int>())
+                .Returns(call => call[1]);
+            settingsByKey.GetEnum(Arg.Any<string>(), Arg.Any<WindowMode>())
+                .Returns(call => call[1]);
+            return settingsByKey;
+        }
+        
+        private DisplaySettings GetDefaultDisplaySettings()
+        {
+            return new DisplaySettings
+            {
+                windowMode = WindowMode.FullScreen,
+                resolutionSizeIndex = 0,
+                vSync = false
+            };
+        }
+    }
+}

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs.meta
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/PlayerPrefsDesktopDisplaySettingsRepositoryShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 858dbbe6c3edbc54584f5d05ad51b63f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/SettingsDesktopTests.asmdef
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/SettingsDesktopTests.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "SettingsDesktopTests",
+    "rootNamespace": "",
+    "references": [
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:0808274fbf804428b871b403dc5b457d",
+        "GUID:301149363e31a4bdaa1943465a825c8e"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/SettingsDesktopTests.asmdef.meta
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/Tests/SettingsDesktopTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0200f489100e3b0418749cac24a00838
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

In #33 I deleted tests to unblock the Desktop Pipeline because we had some problems with `NSubstitute`.

In this PR we're re-adding the test.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
