### PR TITLE
chore: fps hardcap

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/VSyncControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/VSyncControlController.cs
@@ -16,6 +16,11 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             var value = (bool)newValue;
             currentDisplaySettings.vSync = value;
             QualitySettings.vSyncCount = value ? 1 : 0;
+            
+            if (!currentDisplaySettings.vSync)
+            {
+                Application.targetFrameRate = 240;
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Hard caps FPS to 240 when v-sync is disabled to avoid melting fast GPUs
Fixes https://github.com/decentraland/unity-renderer/issues/1507
Fixes https://github.com/decentraland/unity-renderer/issues/478

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
