### PR TITLE
fix: fatal error freeze

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/LoadingFlow/LoadingFlowController.asmdef
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/LoadingFlow/LoadingFlowController.asmdef
@@ -13,7 +13,8 @@
         "GUID:f61959fee36e2416a8d362abc6e87159",
         "GUID:760a1d365aad58044916992b072cf2a6",
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
-        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8"
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -1,4 +1,3 @@
-using UnityEngine;
 using MainScripts.DCL.Controllers.HUD.Preloading;
 using MainScripts.DCL.Controllers.LoadingFlow;
 using MainScripts.DCL.Utils;
@@ -65,7 +64,7 @@ namespace DCL
 
         protected override void Start()
         {
-            loadingFlowController = new LoadingFlowController(Reload);
+            loadingFlowController = new LoadingFlowController(Reload, DataStore.i.HUDs.loadingHUD.fatalError);
             base.Start();
         }
 


### PR DESCRIPTION
## What does this PR change?

Shows the timeout popup during loading screen when any fatal error ocurred on renderer while loading assets.

## How to test the changes?

1. Start DCL many times
2. The loading should never freeze at 99%

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
