### PR TITLE
fix: desktop-only settings not showing up

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Resources/SettingsPanelHUDDesktop.prefab
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Resources/SettingsPanelHUDDesktop.prefab
@@ -7,6 +7,17 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 353294522546651223, guid: 0b30cc33a2ec8433482cf01cdb31bc5f,
+        type: 3}
+      propertyPath: m_Name
+      value: SettingsPanelHUDDesktop
+      objectReference: {fileID: 0}
+    - target: {fileID: 3648780045264160046, guid: 0b30cc33a2ec8433482cf01cdb31bc5f,
+        type: 3}
+      propertyPath: settingsPanelConfig
+      value: 
+      objectReference: {fileID: 11400000, guid: abe1bd817d9be4f3a9603228276f90d1,
+        type: 2}
     - target: {fileID: 353294522546651223, guid: c3951b29ce28ae247a1154a9d3787f77,
         type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
## What does this PR change?

Fixed Desktop settings not showing up

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
