### PR TITLE
fix: loading flow also considers web socket connection timeout

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/LoadingFlow/Resources/LoadingFlow.prefab
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/LoadingFlow/Resources/LoadingFlow.prefab
@@ -460,7 +460,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
-  m_SortingOrder: 50
+  m_SortingOrder: 1000
   m_TargetDisplay: 0
 --- !u!114 &6049894821634335351
 MonoBehaviour:

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -102,7 +102,8 @@ namespace DCL
                 Reload,
                 DataStore.i.HUDs.loadingHUD.fatalError,
                 DataStore.i.HUDs.loadingHUD.visible,
-                CommonScriptableObjects.rendererState);
+                CommonScriptableObjects.rendererState,
+                DataStore.i.wsCommunication.communicationEstablished);
             base.Start();
         }
 


### PR DESCRIPTION
## What does this PR change?

Added a 15 seconds timeout for web socket connection during the loading process. The timeout will trigger the loading error popup.

## How to test the changes?

There is not an easy to test this, since its something that happens sometimes. You can follow the steps forcing the error:
1. Go to class `DCLWebSocketService`
2. Comment the method `OnOpen()`
3. Start the loading flow
4. After 15 seconds a timeout popup should appear

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
