### PR TITLE
Fixing wrong URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Decentraland Explorer Desktop
 
-This repository contains the project to compile [Unity Renderer](https://github.com/decentraland/unity-renderer) to Windows/Mac/Linux and distribute it with the [kernel](https://github.com/decentraland/explorer).
+This repository contains the project to compile [Unity Renderer](https://github.com/decentraland/unity-renderer) to Windows/Mac/Linux and distribute it with the [kernel](https://github.com/decentraland/kernel).
 
 ## Before you start
 


### PR DESCRIPTION
## What does this PR change?

Fixes a wrong URL redirect in the README file (https://github.com/decentraland/explorer -> https://github.com/decentraland/kernel)

...

## How to test the changes?

NA


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
