### PR TITLE
fix: disabled FFMPEG video decoder plugin that was causing crashes

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.asmdef
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.asmdef
@@ -19,7 +19,8 @@
         "GUID:c6e3ac0a2748a14e2b281e440c082eb6",
         "GUID:cc6bfabbfe87b7949aa248893f89ce37",
         "GUID:bd51ff2b035ce4ab4be7c38c43c88889",
-        "GUID:34c2f62e459a9ce49b7a135ff20e2d45"
+        "GUID:34c2f62e459a9ce49b7a135ff20e2d45",
+        "GUID:1cd9f56ea305aae458297148eecef98c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -25,12 +25,12 @@ namespace DCL
         {
             CommandLineParserUtils.ParseArguments();
             isConnectionLost = false;
-
+/*
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
             FFMPEGDecoderWrapper.nativeCleanAll();
             DCLVideoTexture.videoPluginWrapperBuilder = () => new VideoPluginWrapper_FFMPEG();
 #endif
-
+*/
             InitializeSettings();
 
             base.Awake();
@@ -46,9 +46,16 @@ namespace DCL
             //              IntegrationTestSuite_Legacy base class.
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
             {
+                var withSSL = true;
                 int startPort = CommandLineParserUtils.startPort;
+                
+                #if UNITY_EDITOR
+                withSSL = false;
+                startPort = 5000;
+                #endif
+                
                 int endPort = startPort + 100;
-                kernelCommunication = new WebSocketCommunication(true, startPort, endPort);
+                kernelCommunication = new WebSocketCommunication(withSSL, startPort, endPort);
             }
             
         }
@@ -90,9 +97,10 @@ namespace DCL
             loadingFlowController.Dispose();
             preloadingController.Dispose();
             DataStore.i.wsCommunication.communicationEstablished.OnChange -= OnCommunicationEstablished;
+            /*
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
             FFMPEGDecoderWrapper.nativeCleanAll();
-#endif
+#endif*/
         }
 
         void OnCommunicationEstablished(bool current, bool previous)

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -50,7 +50,7 @@ namespace DCL
                 int startPort = CommandLineParserUtils.startPort;
                 
                 #if UNITY_EDITOR
-                withSSL = false;
+                withSSL = DebugConfigComponent.i.webSocketSSL;
                 startPort = 5000;
                 #endif
                 

--- a/unity-renderer-desktop/Packages/manifest.json
+++ b/unity-renderer-desktop/Packages/manifest.json
@@ -1,1 +1,14 @@
-{ "dependencies": { "com.coffee.git-dependency-resolver": "https://github.com/mob-sakai/GitDependencyResolverForUnity.git", "com.decentraland.unity-renderer": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#master", "com.unity.cinemachine": "2.7.4", "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask", "com.unity.testtools.codecoverage": "1.1.0", "com.unity.toolchain.linux-x86_64": "0.1.18-preview", "net.tnrd.nsubstitute": "https://github.com/decentraland/Unity3D-NSubstitute.git" }, "testables": [ "com.decentraland.unity-renderer" ] }
+{
+  "dependencies": {
+    "com.coffee.git-dependency-resolver": "https://github.com/mob-sakai/GitDependencyResolverForUnity.git",
+    "com.decentraland.unity-renderer": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#master",
+    "com.unity.cinemachine": "2.7.4",
+    "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
+    "com.unity.testtools.codecoverage": "1.1.0",
+    "com.unity.toolchain.linux-x86_64": "0.1.18-preview",
+    "net.tnrd.nsubstitute": "https://github.com/decentraland/Unity3D-NSubstitute.git"
+  },
+  "testables": [
+    "com.decentraland.unity-renderer"
+  ]
+}

--- a/unity-renderer-desktop/Packages/packages-lock.json
+++ b/unity-renderer-desktop/Packages/packages-lock.json
@@ -1,1 +1,547 @@
-{ "dependencies": { "com.coffee.git-dependency-resolver": { "version": "https://github.com/mob-sakai/GitDependencyResolverForUnity.git", "depth": 0, "source": "git", "dependencies": {}, "hash": "d4fc38c92fb139b4184912f20556ab27a3b519fa" }, "com.decentraland.unity-renderer": { "version": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#master", "depth": 0, "source": "git", "dependencies": { "com.unity.2d.sprite": "1.0.0", "com.unity.2d.tilemap": "1.0.0", "com.unity.cinemachine": "2.5.0", "com.unity.ide.rider": "2.0.7", "com.unity.ide.visualstudio": "2.0.7", "com.unity.ide.vscode": "1.2.3", "com.unity.memoryprofiler": "0.2.4-preview.1", "com.unity.performance.profile-analyzer": "1.0.3", "com.unity.postprocessing": "3.1.0", "com.unity.render-pipelines.universal": "10.4.0", "com.unity.scriptablebuildpipeline": "1.17.0", "com.unity.shadergraph": "10.3.2", "com.unity.test-framework": "1.1.22", "com.unity.test-framework.performance": "1.3.3-preview", "com.unity.textmeshpro": "3.0.4", "com.unity.timeline": "1.4.6", "com.unity.ugui": "1.0.0", "com.unity.xr.legacyinputhelpers": "2.1.7", "com.unity.modules.androidjni": "1.0.0", "com.unity.modules.animation": "1.0.0", "com.unity.modules.assetbundle": "1.0.0", "com.unity.modules.audio": "1.0.0", "com.unity.modules.director": "1.0.0", "com.unity.modules.imageconversion": "1.0.0", "com.unity.modules.imgui": "1.0.0", "com.unity.modules.jsonserialize": "1.0.0", "com.unity.modules.particlesystem": "1.0.0", "com.unity.modules.physics": "1.0.0", "com.unity.modules.physics2d": "1.0.0", "com.unity.modules.screencapture": "1.0.0", "com.unity.modules.terrain": "1.0.0", "com.unity.modules.terrainphysics": "1.0.0", "com.unity.modules.tilemap": "1.0.0", "com.unity.modules.ui": "1.0.0", "com.unity.modules.uielements": "1.0.0", "com.unity.modules.umbra": "1.0.0", "com.unity.modules.unityanalytics": "1.0.0", "com.unity.modules.unitywebrequest": "1.0.0", "com.unity.modules.unitywebrequestassetbundle": "1.0.0", "com.unity.modules.unitywebrequestaudio": "1.0.0", "com.unity.modules.unitywebrequesttexture": "1.0.0", "com.unity.modules.unitywebrequestwww": "1.0.0", "com.unity.modules.video": "1.0.0", "com.unity.modules.vr": "1.0.0", "com.unity.modules.xr": "1.0.0" }, "hash": "dc9f2c703a6e51c444fba16e0ca93e700ac6c336" }, "com.unity.2d.sprite": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.2d.tilemap": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.cinemachine": { "version": "2.7.4", "depth": 0, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.editorcoroutines": { "version": "1.0.0", "depth": 2, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.ext.nunit": { "version": "1.0.6", "depth": 2, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.ide.rider": { "version": "2.0.7", "depth": 1, "source": "registry", "dependencies": { "com.unity.test-framework": "1.1.1" }, "url": "https://packages.unity.com" }, "com.unity.ide.visualstudio": { "version": "2.0.7", "depth": 1, "source": "registry", "dependencies": { "com.unity.test-framework": "1.1.9" }, "url": "https://packages.unity.com" }, "com.unity.ide.vscode": { "version": "1.2.3", "depth": 1, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.mathematics": { "version": "1.1.0", "depth": 2, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.memoryprofiler": { "version": "0.2.4-preview.1", "depth": 1, "source": "registry", "dependencies": { "com.unity.editorcoroutines": "1.0.0" }, "url": "https://packages.unity.com" }, "com.unity.performance.profile-analyzer": { "version": "1.0.3", "depth": 1, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.postprocessing": { "version": "3.1.0", "depth": 1, "source": "registry", "dependencies": { "com.unity.modules.physics": "1.0.0" }, "url": "https://packages.unity.com" }, "com.unity.render-pipelines.core": { "version": "10.4.0", "depth": 2, "source": "registry", "dependencies": { "com.unity.ugui": "1.0.0" }, "url": "https://packages.unity.com" }, "com.unity.render-pipelines.universal": { "version": "10.4.0", "depth": 1, "source": "registry", "dependencies": { "com.unity.mathematics": "1.1.0", "com.unity.render-pipelines.core": "10.4.0", "com.unity.shadergraph": "10.4.0" }, "url": "https://packages.unity.com" }, "com.unity.scriptablebuildpipeline": { "version": "1.17.0", "depth": 1, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.searcher": { "version": "4.3.1", "depth": 2, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.settings-manager": { "version": "1.0.1", "depth": 1, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.shadergraph": { "version": "10.4.0", "depth": 2, "source": "registry", "dependencies": { "com.unity.render-pipelines.core": "10.4.0", "com.unity.searcher": "4.3.1" }, "url": "https://packages.unity.com" }, "com.unity.sysroot": { "version": "0.1.19-preview", "depth": 1, "source": "registry", "dependencies": {}, "url": "https://packages.unity.com" }, "com.unity.sysroot.linux-x86_64": { "version": "0.1.14-preview", "depth": 1, "source": "registry", "dependencies": { "com.unity.sysroot": "0.1.18-preview" }, "url": "https://packages.unity.com" }, "com.unity.test-framework": { "version": "1.1.22", "depth": 1, "source": "registry", "dependencies": { "com.unity.ext.nunit": "1.0.6", "com.unity.modules.imgui": "1.0.0", "com.unity.modules.jsonserialize": "1.0.0" }, "url": "https://packages.unity.com" }, "com.unity.test-framework.performance": { "version": "1.3.3-preview", "depth": 1, "source": "registry", "dependencies": { "com.unity.test-framework": "1.1.0", "com.unity.modules.jsonserialize": "1.0.0" }, "url": "https://packages.unity.com" }, "com.unity.testtools.codecoverage": { "version": "1.1.0", "depth": 0, "source": "registry", "dependencies": { "com.unity.test-framework": "1.0.16", "com.unity.settings-manager": "1.0.1" }, "url": "https://packages.unity.com" }, "com.unity.textmeshpro": { "version": "3.0.4", "depth": 1, "source": "registry", "dependencies": { "com.unity.ugui": "1.0.0" }, "url": "https://packages.unity.com" }, "com.unity.timeline": { "version": "1.4.6", "depth": 1, "source": "registry", "dependencies": { "com.unity.modules.director": "1.0.0", "com.unity.modules.animation": "1.0.0", "com.unity.modules.audio": "1.0.0", "com.unity.modules.particlesystem": "1.0.0" }, "url": "https://packages.unity.com" }, "com.unity.toolchain.linux-x86_64": { "version": "0.1.18-preview", "depth": 0, "source": "registry", "dependencies": { "com.unity.sysroot": "0.1.19-preview", "com.unity.sysroot.linux-x86_64": "0.1.14-preview" }, "url": "https://packages.unity.com" }, "com.unity.ugui": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.ui": "1.0.0", "com.unity.modules.imgui": "1.0.0" } }, "com.unity.xr.legacyinputhelpers": { "version": "2.1.7", "depth": 1, "source": "registry", "dependencies": { "com.unity.modules.vr": "1.0.0", "com.unity.modules.xr": "1.0.0" }, "url": "https://packages.unity.com" }, "net.tnrd.nsubstitute": { "version": "file:.net.tnrd.nsubstitute@4.2.2", "depth": 0, "source": "embedded", "dependencies": {} }, "com.unity.modules.androidjni": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.animation": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.assetbundle": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.audio": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.director": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.audio": "1.0.0", "com.unity.modules.animation": "1.0.0" } }, "com.unity.modules.imageconversion": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.imgui": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.jsonserialize": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.particlesystem": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.physics": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.physics2d": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.screencapture": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.imageconversion": "1.0.0" } }, "com.unity.modules.subsystems": { "version": "1.0.0", "depth": 2, "source": "builtin", "dependencies": { "com.unity.modules.jsonserialize": "1.0.0" } }, "com.unity.modules.terrain": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.terrainphysics": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.physics": "1.0.0", "com.unity.modules.terrain": "1.0.0" } }, "com.unity.modules.tilemap": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.physics2d": "1.0.0" } }, "com.unity.modules.ui": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.uielements": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.ui": "1.0.0", "com.unity.modules.imgui": "1.0.0", "com.unity.modules.jsonserialize": "1.0.0", "com.unity.modules.uielementsnative": "1.0.0" } }, "com.unity.modules.uielementsnative": { "version": "1.0.0", "depth": 2, "source": "builtin", "dependencies": { "com.unity.modules.ui": "1.0.0", "com.unity.modules.imgui": "1.0.0", "com.unity.modules.jsonserialize": "1.0.0" } }, "com.unity.modules.umbra": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.unityanalytics": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.unitywebrequest": "1.0.0", "com.unity.modules.jsonserialize": "1.0.0" } }, "com.unity.modules.unitywebrequest": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": {} }, "com.unity.modules.unitywebrequestassetbundle": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.assetbundle": "1.0.0", "com.unity.modules.unitywebrequest": "1.0.0" } }, "com.unity.modules.unitywebrequestaudio": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.unitywebrequest": "1.0.0", "com.unity.modules.audio": "1.0.0" } }, "com.unity.modules.unitywebrequesttexture": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.unitywebrequest": "1.0.0", "com.unity.modules.imageconversion": "1.0.0" } }, "com.unity.modules.unitywebrequestwww": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.unitywebrequest": "1.0.0", "com.unity.modules.unitywebrequestassetbundle": "1.0.0", "com.unity.modules.unitywebrequestaudio": "1.0.0", "com.unity.modules.audio": "1.0.0", "com.unity.modules.assetbundle": "1.0.0", "com.unity.modules.imageconversion": "1.0.0" } }, "com.unity.modules.video": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.audio": "1.0.0", "com.unity.modules.ui": "1.0.0", "com.unity.modules.unitywebrequest": "1.0.0" } }, "com.unity.modules.vr": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.jsonserialize": "1.0.0", "com.unity.modules.physics": "1.0.0", "com.unity.modules.xr": "1.0.0" } }, "com.unity.modules.xr": { "version": "1.0.0", "depth": 1, "source": "builtin", "dependencies": { "com.unity.modules.physics": "1.0.0", "com.unity.modules.jsonserialize": "1.0.0", "com.unity.modules.subsystems": "1.0.0" } } } }
+{
+  "dependencies": {
+    "com.coffee.git-dependency-resolver": {
+      "version": "https://github.com/mob-sakai/GitDependencyResolverForUnity.git",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "d4fc38c92fb139b4184912f20556ab27a3b519fa"
+    },
+    "com.coffee.ui-particle": {
+      "version": "file:.com.coffee.ui-particle@3.3.9",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {}
+    },
+    "com.cysharp.unitask": {
+      "version": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "27604496ca1b27b93d78dd2257a50158fab2bc33"
+    },
+    "com.decentraland.unity-renderer": {
+      "version": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#master",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.2d.tilemap": "1.0.0",
+        "com.unity.cinemachine": "2.5.0",
+        "com.unity.ide.rider": "2.0.7",
+        "com.unity.ide.visualstudio": "2.0.7",
+        "com.unity.ide.vscode": "1.2.3",
+        "com.unity.memoryprofiler": "0.2.4-preview.1",
+        "com.unity.performance.profile-analyzer": "1.0.3",
+        "com.unity.postprocessing": "3.1.0",
+        "com.unity.render-pipelines.universal": "10.4.0",
+        "com.unity.scriptablebuildpipeline": "1.17.0",
+        "com.unity.shadergraph": "10.3.2",
+        "com.unity.test-framework": "1.1.22",
+        "com.unity.test-framework.performance": "1.3.3-preview",
+        "com.unity.textmeshpro": "3.0.4",
+        "com.unity.timeline": "1.4.6",
+        "com.unity.ugui": "1.0.0",
+        "com.unity.xr.legacyinputhelpers": "2.1.7",
+        "com.unity.modules.androidjni": "1.0.0",
+        "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.director": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.particlesystem": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.physics2d": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0",
+        "com.unity.modules.terrain": "1.0.0",
+        "com.unity.modules.terrainphysics": "1.0.0",
+        "com.unity.modules.tilemap": "1.0.0",
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.umbra": "1.0.0",
+        "com.unity.modules.unityanalytics": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequestaudio": "1.0.0",
+        "com.unity.modules.unitywebrequesttexture": "1.0.0",
+        "com.unity.modules.unitywebrequestwww": "1.0.0",
+        "com.unity.modules.video": "1.0.0",
+        "com.unity.modules.vr": "1.0.0",
+        "com.unity.modules.xr": "1.0.0"
+      },
+      "hash": "dc9f2c703a6e51c444fba16e0ca93e700ac6c336"
+    },
+    "com.unity.2d.sprite": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.2d.tilemap": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.cinemachine": {
+      "version": "2.7.4",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.editorcoroutines": {
+      "version": "1.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ide.rider": {
+      "version": "2.0.7",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.1"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ide.visualstudio": {
+      "version": "2.0.7",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.9"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ide.vscode": {
+      "version": "1.2.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.mathematics": {
+      "version": "1.1.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.memoryprofiler": {
+      "version": "0.2.4-preview.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.editorcoroutines": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.performance.profile-analyzer": {
+      "version": "1.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.postprocessing": {
+      "version": "3.1.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.render-pipelines.core": {
+      "version": "10.4.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.render-pipelines.universal": {
+      "version": "10.4.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.1.0",
+        "com.unity.render-pipelines.core": "10.4.0",
+        "com.unity.shadergraph": "10.4.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.scriptablebuildpipeline": {
+      "version": "1.17.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.searcher": {
+      "version": "4.3.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.settings-manager": {
+      "version": "1.0.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.shadergraph": {
+      "version": "10.4.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.render-pipelines.core": "10.4.0",
+        "com.unity.searcher": "4.3.1"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot": {
+      "version": "0.1.19-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "0.1.14-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "0.1.18-preview"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.22",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework.performance": {
+      "version": "1.3.3-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.testtools.codecoverage": {
+      "version": "1.1.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.0.16",
+        "com.unity.settings-manager": "1.0.1"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.textmeshpro": {
+      "version": "3.0.4",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.timeline": {
+      "version": "1.4.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.director": "1.0.0",
+        "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.linux-x86_64": {
+      "version": "0.1.18-preview",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "0.1.19-preview",
+        "com.unity.sysroot.linux-x86_64": "0.1.14-preview"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ugui": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0"
+      }
+    },
+    "com.unity.xr.legacyinputhelpers": {
+      "version": "2.1.7",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.vr": "1.0.0",
+        "com.unity.modules.xr": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "net.tnrd.nsubstitute": {
+      "version": "file:.net.tnrd.nsubstitute@4.2.2",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {}
+    },
+    "com.unity.modules.androidjni": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.animation": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.assetbundle": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.audio": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.director": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.animation": "1.0.0"
+      }
+    },
+    "com.unity.modules.imageconversion": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.imgui": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.jsonserialize": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.particlesystem": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.physics": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.physics2d": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.screencapture": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.subsystems": {
+      "version": "1.0.0",
+      "depth": 2,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.terrain": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.terrainphysics": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.terrain": "1.0.0"
+      }
+    },
+    "com.unity.modules.tilemap": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics2d": "1.0.0"
+      }
+    },
+    "com.unity.modules.ui": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.uielements": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.uielementsnative": "1.0.0"
+      }
+    },
+    "com.unity.modules.uielementsnative": {
+      "version": "1.0.0",
+      "depth": 2,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.umbra": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.unityanalytics": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequest": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.unitywebrequestassetbundle": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequestaudio": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.audio": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequesttexture": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequestwww": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequestaudio": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.video": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      }
+    },
+    "com.unity.modules.vr": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.xr": "1.0.0"
+      }
+    },
+    "com.unity.modules.xr": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.subsystems": "1.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR change?

Fixes a random crash caused by FFMPEG decoder by disabling the plugin temporaly

Also fixed Unity forced SSL and port

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
