### PR TITLE
test: use loading stuck fix from unity-renderer package

### DIFF
--- a/unity-renderer-desktop/Packages/manifest.json
+++ b/unity-renderer-desktop/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.coffee.git-dependency-resolver": "https://github.com/mob-sakai/GitDependencyResolverForUnity.git",
-    "com.decentraland.unity-renderer": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#master",
+    "com.decentraland.unity-renderer": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#fix/ScenesStuckLoadingOnGLTFsPromiseSilentForget",
     "com.unity.cinemachine": "2.7.4",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.unity.testtools.codecoverage": "1.1.0",

--- a/unity-renderer-desktop/Packages/packages-lock.json
+++ b/unity-renderer-desktop/Packages/packages-lock.json
@@ -21,7 +21,7 @@
       "hash": "27604496ca1b27b93d78dd2257a50158fab2bc33"
     },
     "com.decentraland.unity-renderer": {
-      "version": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#master",
+      "version": "git+https://github.com/decentraland/unity-renderer.git?path=unity-renderer/Assets#fix/ScenesStuckLoadingOnGLTFsPromiseSilentForget",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -71,7 +71,7 @@
         "com.unity.modules.vr": "1.0.0",
         "com.unity.modules.xr": "1.0.0"
       },
-      "hash": "dc9f2c703a6e51c444fba16e0ca93e700ac6c336"
+      "hash": "fa747cbe5d378af438b718ca10dd5f8bf9ec4493"
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",


### PR DESCRIPTION
changed unity-renderer package to point to the branch that has the scenes-loading-stuck fix