### PR TITLE
fix: vsync toggle color

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ToggleSettingsControlTemplateDesktop.prefab
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ToggleSettingsControlTemplateDesktop.prefab
@@ -339,7 +339,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.8745098, g: 0.8745098, b: 0.8745098, a: 1}
+  m_Color: {r: 0.62352943, g: 0.62352943, b: 0.62352943, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1


### PR DESCRIPTION
## What does this PR change?

Fixes the color of v-sync toggle's background to be the same as the rest.

## How to test the changes?

1. Open the settings panel (press TAB)
2. Set window mode to full screen
3. Click the vsync toggle
4. Check that the background color is correct

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
