### PR TITLE
fix: gif nftshapes preview modal breaks subsequent preview modals

### DIFF
--- a/unity-renderer-desktop/Packages/packages-lock.json
+++ b/unity-renderer-desktop/Packages/packages-lock.json
@@ -71,7 +71,7 @@
         "com.unity.modules.vr": "1.0.0",
         "com.unity.modules.xr": "1.0.0"
       },
-      "hash": "3cb6547ef1790f53a91af3f18211a626230dd121"
+      "hash": "8a8a2cfa308c420c8eccd308d650bcf65c48a4e6"
     },
     "com.mediadecoder.ffmpeg": {
       "version": "git+https://github.com/decentraland/FFMPEGMediaDecoder.git?path=FFMPEGDecoderPlugin#master",


### PR DESCRIPTION
## What does this PR change?

Includes the unity-renderer commit that fixes the gif overlapping issue

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
