### PR TITLE
chore: remove targetframerate override to fix fps cap

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/VSyncControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/VSyncControlController.cs
@@ -16,11 +16,6 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             var value = (bool)newValue;
             currentDisplaySettings.vSync = value;
             QualitySettings.vSyncCount = value ? 1 : 0;
-            
-            if (!currentDisplaySettings.vSync)
-            {
-                Application.targetFrameRate = 240;
-            }
         }
     }
 }

--- a/unity-renderer-desktop/Packages/packages-lock.json
+++ b/unity-renderer-desktop/Packages/packages-lock.json
@@ -71,7 +71,7 @@
         "com.unity.modules.vr": "1.0.0",
         "com.unity.modules.xr": "1.0.0"
       },
-      "hash": "8a8a2cfa308c420c8eccd308d650bcf65c48a4e6"
+      "hash": "2fd82b165f1009256988dfe6c914959126c7e5f8"
     },
     "com.mediadecoder.ffmpeg": {
       "version": "git+https://github.com/decentraland/FFMPEGMediaDecoder.git?path=FFMPEGDecoderPlugin#master",


### PR DESCRIPTION
Removed target framerate override to fix FPSCap in unity-renderer side, the max FPS requested (240) will be applied in the unity-side PR (https://github.com/decentraland/unity-renderer/pull/1983).

We should wait until we merged https://github.com/decentraland/unity-renderer/pull/1983 and updated the unity-renderer consumed package version before merging this PR