### PR TITLE
chore: update version

### DIFF
--- a/unity-renderer-desktop/Packages/packages-lock.json
+++ b/unity-renderer-desktop/Packages/packages-lock.json
@@ -71,7 +71,7 @@
         "com.unity.modules.vr": "1.0.0",
         "com.unity.modules.xr": "1.0.0"
       },
-      "hash": "4ce1baf25460d27856d8c5b3c193527cbd9e462a"
+      "hash": "4d65fb82d0c226916b0f2bb58d3d1ede88088bcd"
     },
     "com.mediadecoder.ffmpeg": {
       "version": "git+https://github.com/decentraland/FFMPEGMediaDecoder.git?path=FFMPEGDecoderPlugin#master",


### PR DESCRIPTION
Updated commit consumed from unity-renderer to last one before 67d2a2a5a1891a18f0a44304f754103f37bd8c91 (feat: emotes catalog (#1992)) as that one introduces a problem loading the character in desktop