### PR TITLE
chore: emoteAnimations plugin is now implemented.

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystemDesktop/PluginSystemDesktop.asmdef
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystemDesktop/PluginSystemDesktop.asmdef
@@ -21,7 +21,8 @@
         "GUID:dd2bdb4c07be4110a5b57bf41484b080",
         "GUID:7ac9f9c835ec1084ab35e3f9b176cf1e",
         "GUID:044764b0a8d94a2fbdcdc9e02e6da0de",
-        "GUID:873fc6254de64e84ba87ff26c2bbafca"
+        "GUID:873fc6254de64e84ba87ff26c2bbafca",
+        "GUID:81fbd0260d07a69449fb0fc6ed29d254"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystemDesktop/PluginSystemFactoryDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/PluginSystemDesktop/PluginSystemFactoryDesktop.cs
@@ -1,3 +1,4 @@
+using DCL.Emotes;
 using DCL.Tutorial;
 using DCL.Skybox;
 
@@ -16,6 +17,7 @@ namespace DCL
             pluginSystem.Register(() => new TransactionFeature());
             pluginSystem.Register(() => new PreviewMenuPlugin());
             pluginSystem.Register(() => new SkyboxController());
+            pluginSystem.Register(() => new EmoteAnimationsPlugin(DataStore.i.emotes));
             pluginSystem.RegisterWithFlag(() => new BuilderInWorldPlugin(), "builder_in_world");
             pluginSystem.RegisterWithFlag(() => new TutorialController(), "tutorial");
             pluginSystem.RegisterWithFlag(() => new PlacesAndEventsFeature(), "explorev2");

--- a/unity-renderer-desktop/Packages/packages-lock.json
+++ b/unity-renderer-desktop/Packages/packages-lock.json
@@ -71,7 +71,7 @@
         "com.unity.modules.vr": "1.0.0",
         "com.unity.modules.xr": "1.0.0"
       },
-      "hash": "4ce1baf25460d27856d8c5b3c193527cbd9e462a"
+      "hash": "fb544c3be48e99fabd8d71540724cd9bf2dc676d"
     },
     "com.mediadecoder.ffmpeg": {
       "version": "git+https://github.com/decentraland/FFMPEGMediaDecoder.git?path=FFMPEGDecoderPlugin#master",


### PR DESCRIPTION
Emote animations plugins was not implemented here and therefore throwing errors.

In any case gonna add some validation in the main renderer so the plugin it can actually be removed without breaking anything.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
