### PR TITLE
fix: resolution workaround to avoid small resolutions on big displays

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/ResolutionSizeControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/ResolutionSizeControlController.cs
@@ -18,6 +18,7 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             SetupLabels();
         }
 
+        // Filter the smallest resolutions as no one will ever use them
         private void SetupAvailableResolutions()
         {
             availableFilteredResolutions = Screen.resolutions.Where(r => r.width >= 1024 && r.refreshRate > 0).ToArray();
@@ -30,6 +31,9 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             for (var i = 0; i < length; i++)
             {
                 Resolution resolution = availableFilteredResolutions[i];
+                
+                // by design we want the list to be inverted so the biggest resolutions stay on top
+                // our resolutionSizeIndex is based on this decision
                 resolutionLabels[length - 1 - i] = GetLabel(resolution);
             }
 

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
@@ -1,4 +1,5 @@
 using System;
+using Cysharp.Threading.Tasks;
 using MainScripts.DCL.Controllers.SettingsDesktop;
 using MainScripts.DCL.Controllers.SettingsDesktop.SettingsControllers;
 using MainScripts.DCL.ScriptableObjectsDesktop;
@@ -25,10 +26,7 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
                     Screen.fullScreenMode = FullScreenMode.Windowed;
                     break;
                 case WindowMode.Borderless:
-                    var maxRes = Screen.resolutions[Screen.resolutions.Length - 1];
-                    Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
-                    Screen.SetResolution(maxRes.width, maxRes.height, FullScreenMode.FullScreenWindow, maxRes.refreshRate);
-                    currentDisplaySettings.resolutionSizeIndex = 0;
+                    SetupBorderless().Forget();
                     break;
                 case WindowMode.FullScreen:
                     Screen.fullScreen = true;
@@ -40,6 +38,15 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
 
             CommonScriptableObjectsDesktop.disableVSync.Set(currentDisplaySettings.windowMode == WindowMode.Windowed);
             CommonScriptableObjectsDesktop.disableScreenResolution.Set(currentDisplaySettings.windowMode == WindowMode.Borderless);
+        }
+
+        private async UniTaskVoid SetupBorderless()
+        {
+            var maxRes = Screen.resolutions[Screen.resolutions.Length - 1];
+            Screen.SetResolution(maxRes.width, maxRes.height, Screen.fullScreenMode, maxRes.refreshRate);
+            await UniTask.WaitForEndOfFrame();
+            Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
+            currentDisplaySettings.resolutionSizeIndex = 0;
         }
     }
 }

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
@@ -61,6 +61,7 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             await UniTask.WaitForEndOfFrame();
             Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
             currentDisplaySettings.resolutionSizeIndex = 0;
+            ApplySettings();
         }
     }
 }

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
@@ -18,7 +18,6 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
         public override void UpdateSetting(object newValue)
         {
             currentDisplaySettings.windowMode = (WindowMode)(int)newValue;
-
             switch (currentDisplaySettings.windowMode)
             {
                 case WindowMode.Windowed:
@@ -27,7 +26,8 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
                     break;
                 case WindowMode.Borderless:
                     var maxRes = Screen.resolutions[Screen.resolutions.Length - 1];
-                    Screen.SetResolution(maxRes.width, maxRes.height, FullScreenMode.MaximizedWindow, maxRes.refreshRate);
+                    Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
+                    Screen.SetResolution(maxRes.width, maxRes.height, FullScreenMode.FullScreenWindow, maxRes.refreshRate);
                     currentDisplaySettings.resolutionSizeIndex = 0;
                     break;
                 case WindowMode.FullScreen:

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
@@ -22,15 +22,13 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             switch (currentDisplaySettings.windowMode)
             {
                 case WindowMode.Windowed:
-                    Screen.fullScreen = false;
-                    Screen.fullScreenMode = FullScreenMode.Windowed;
+                    SetupWindowed().Forget();
                     break;
                 case WindowMode.Borderless:
                     SetupBorderless().Forget();
                     break;
                 case WindowMode.FullScreen:
-                    Screen.fullScreen = true;
-                    Screen.fullScreenMode = FullScreenMode.ExclusiveFullScreen;
+                    SetupFullScreen().Forget();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -40,6 +38,22 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             CommonScriptableObjectsDesktop.disableScreenResolution.Set(currentDisplaySettings.windowMode == WindowMode.Borderless);
         }
 
+        //NOTE(Kinerius): We have to wait a single frame between changing screen mode and resolution because one of them fails if done at the same frame for some reason
+        
+        private async UniTaskVoid SetupFullScreen()
+        {
+            Screen.fullScreen = true;
+            await UniTask.WaitForEndOfFrame();
+            Screen.fullScreenMode = FullScreenMode.ExclusiveFullScreen;
+        }
+
+        private async UniTaskVoid SetupWindowed()
+        {
+            Screen.fullScreen = false;
+            await UniTask.WaitForEndOfFrame();
+            Screen.fullScreenMode = FullScreenMode.Windowed;
+        }
+        
         private async UniTaskVoid SetupBorderless()
         {
             var maxRes = Screen.resolutions[Screen.resolutions.Length - 1];

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
@@ -56,12 +56,10 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
         
         private async UniTaskVoid SetupBorderless()
         {
-            var maxRes = Screen.resolutions[Screen.resolutions.Length - 1];
-            Screen.SetResolution(maxRes.width, maxRes.height, Screen.fullScreenMode, maxRes.refreshRate);
-            await UniTask.WaitForEndOfFrame();
-            Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
             currentDisplaySettings.resolutionSizeIndex = 0;
             ApplySettings();
+            await UniTask.WaitForEndOfFrame();
+            Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
         }
     }
 }

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/SettingsPanelHUDDesktop.asmdef
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/SettingsPanelHUDDesktop.asmdef
@@ -11,7 +11,8 @@
         "GUID:c2d26ac7e5da1476d8138ffda5a029c2",
         "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c"
+        "GUID:1e6b57fe78f7b724e9567f29f6a40c2c",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/DisplaySettings.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/SettingsDesktop/DisplaySettings.cs
@@ -17,5 +17,22 @@ namespace MainScripts.DCL.Controllers.SettingsDesktop
         public WindowMode windowMode;
         public int resolutionSizeIndex;
         public bool vSync;
+
+        public FullScreenMode GetFullScreenMode()
+        {
+            return windowMode switch
+            {
+                WindowMode.Windowed => FullScreenMode.Windowed,
+                WindowMode.Borderless => FullScreenMode.FullScreenWindow,
+                WindowMode.FullScreen => FullScreenMode.ExclusiveFullScreen,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        // Resolution list goes from the smallest to the biggest, our index is inverted for usage reasons so 0 is the biggest resolution available
+        public Resolution GetResolution()
+        {
+            return Screen.resolutions[Screen.resolutions.Length - 1 - resolutionSizeIndex];
+        }
     }
 }

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.asmdef
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.asmdef
@@ -22,7 +22,9 @@
         "GUID:1cd9f56ea305aae458297148eecef98c",
         "GUID:873fc6254de64e84ba87ff26c2bbafca",
         "GUID:e03c97368d8ac984eb5c6325c8ba8a03",
-        "GUID:119334f2afa924907aa5811e7c51af57"
+        "GUID:119334f2afa924907aa5811e7c51af57",
+        "GUID:0808274fbf804428b871b403dc5b457d",
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -4,6 +4,7 @@ using DCL.SettingsCommon;
 using DCL.Components;
 using MainScripts.DCL.Controllers.HUD.Preloading;
 using MainScripts.DCL.Controllers.LoadingFlow;
+using MainScripts.DCL.Controllers.SettingsDesktop;
 using MainScripts.DCL.Utils;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -34,7 +35,7 @@ namespace DCL
             DataStore.i.performance.multithreading.Set(true);
             DataStore.i.performance.maxDownloads.Set(50);
             Texture.allowThreadedTextureCreation = true;
-            CheckForIncorrectScreenSize();
+            SetupScreenResolution();
         }
 
         protected override void InitializeCommunication()
@@ -61,21 +62,11 @@ namespace DCL
             pluginSystem = PluginSystemFactoryDesktop.Create();
         }
 
-        private void CheckForIncorrectScreenSize()
+        private void SetupScreenResolution()
         {
-            var maxRes = Screen.resolutions[Screen.resolutions.Length - 1];
-            bool supports4KResolution = maxRes.width >= 3840;
-            int minWidth = supports4KResolution ? maxRes.width / 2 : 1024;
-            var currentWidth = Screen.currentResolution.width;
-
-            if (currentWidth >= minWidth) return;
-            
-            var availableFilteredResolutions =
-                Screen.resolutions.Where(r => r.width >= minWidth && r.refreshRate > 0).ToArray();
-            
-            var minRes = availableFilteredResolutions[0];
-
-            Screen.SetResolution(minRes.width, minRes.height, Screen.fullScreenMode);
+            var windowMode = SettingsDesktop.i.displaySettings.Data.GetFullScreenMode();
+            var resolution = SettingsDesktop.i.displaySettings.Data.GetResolution();
+            Screen.SetResolution(resolution.width, resolution.height, windowMode);
         }
 
         private void InitializeSettings()

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -64,8 +64,9 @@ namespace DCL
 
         private void SetupScreenResolution()
         {
-            var windowMode = SettingsDesktop.i.displaySettings.Data.GetFullScreenMode();
-            var resolution = SettingsDesktop.i.displaySettings.Data.GetResolution();
+            var displaySettings = SettingsDesktop.i.displaySettings.Data;
+            var windowMode = displaySettings.GetFullScreenMode();
+            var resolution = displaySettings.GetResolution();
             Screen.SetResolution(resolution.width, resolution.height, windowMode);
         }
 

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -115,6 +115,16 @@ namespace DCL
             {
                 DesktopUtils.Quit();
             }
+
+            // TODO: Remove this after we refactor InputController to support overrides from desktop or to use the latest Unity Input System
+            // This shortcut will help some users to fix the small resolution bugs that may happen if the player prefs are manipulated
+            if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                && Input.GetKeyDown(KeyCode.F11))
+            {
+                DisplaySettings newDisplaySettings = new DisplaySettings { windowMode = WindowMode.FullScreen };
+                SettingsDesktop.i.displaySettings.Apply(newDisplaySettings);
+                SettingsDesktop.i.displaySettings.Save();
+            }
         }
 
         protected override void Start()

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -121,7 +121,7 @@ namespace DCL
             if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
                 && Input.GetKeyDown(KeyCode.F11))
             {
-                DisplaySettings newDisplaySettings = new DisplaySettings { windowMode = WindowMode.FullScreen };
+                DisplaySettings newDisplaySettings = new DisplaySettings { windowMode = WindowMode.Borderless };
                 SettingsDesktop.i.displaySettings.Apply(newDisplaySettings);
                 SettingsDesktop.i.displaySettings.Save();
             }


### PR DESCRIPTION
## What does this PR change?

Changed how we handle the initial and startup resolution by just using the one on player prefs, this one defaults as borderless max resolution if not available. (#121)

Added a shortcut ( `CTRL+F11`) to force max resolution and full screen to avoid small resolution issues where you can't get into settings because the UI is not scaling properly.

Also fixed a weird bug that happens when changing from windowed to borderless

## How to test the changes?

Uninstall the launcher so the player-prefs are deleted, then reinstall and launch, application should have a full-screen max resolution setting by default.

Setup the smallest resolution available, close settings, and press `CTRL+F11` to go back to borderless max resolution

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
