### PR TITLE
fix: aspect ratio bug

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Scripts/WindowModeControlController.cs
@@ -39,12 +39,12 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
         }
 
         //NOTE(Kinerius): We have to wait a single frame between changing screen mode and resolution because one of them fails if done at the same frame for some reason
-        
         private async UniTaskVoid SetupFullScreen()
         {
             Screen.fullScreen = true;
             await UniTask.WaitForEndOfFrame();
             Screen.fullScreenMode = FullScreenMode.ExclusiveFullScreen;
+            await UpdateResolution();
         }
 
         private async UniTaskVoid SetupWindowed()
@@ -52,14 +52,24 @@ namespace MainScripts.DCL.Controllers.HUD.SettingsPanelHUDDesktop.Scripts
             Screen.fullScreen = false;
             await UniTask.WaitForEndOfFrame();
             Screen.fullScreenMode = FullScreenMode.Windowed;
+            await UpdateResolution();
         }
-        
+
         private async UniTaskVoid SetupBorderless()
         {
             currentDisplaySettings.resolutionSizeIndex = 0;
             ApplySettings();
             await UniTask.WaitForEndOfFrame();
             Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
+            await UpdateResolution();
+        }
+
+        //NOTE(Kinerius) this fixes a race condition when starting the application
+        private async UniTask UpdateResolution()
+        {
+            await UniTask.WaitForEndOfFrame();
+            Resolution resolution = currentDisplaySettings.GetResolution();
+            Screen.SetResolution(resolution.width, resolution.height, Screen.fullScreenMode);
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

We know that unity doesn't like the resolution size being changed while you are switching from windowed/fullscreen so we are adding a new routine to wait for a frame and re-applying the screen size.

This is an effort to fix https://github.com/decentraland/explorer-desktop/issues/232

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
