### PR TITLE
chore: set max load radius to 4

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset
@@ -20,6 +20,6 @@ MonoBehaviour:
   flagsThatDeactivateMe: []
   isBeta: 0
   sliderMinValue: 1
-  sliderMaxValue: 5
+  sliderMaxValue: 4
   storeValueAsNormalized: 0
   wholeNumbers: 1

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 060c1aa63ccfe124aa3cd640f9286a0b, type: 3}
+  m_Name: ScenesLoadRadiusControlConfigurationDesktop
+  m_EditorClassIdentifier: 
+  title: SCENES LOAD RADIUS
+  controlPrefab: {fileID: 3572563192424337713, guid: 9c69fdd3db1d73140bfff48c5a2f72dd,
+    type: 3}
+  controlController: {fileID: 11400000, guid: a5617d48f1af04692a0965b6ff232360, type: 2}
+  flagsThatDisableMe: []
+  flagsThatDeactivateMe: []
+  isBeta: 0
+  sliderMinValue: 1
+  sliderMaxValue: 5
+  storeValueAsNormalized: 0
+  wholeNumbers: 1

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset.meta
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3ec1619997f2e646a6ca99a92a902f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/SettingsPanelConfigurationDesktop.asset
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/SettingsPanelConfigurationDesktop.asset
@@ -14,6 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   sections:
     array:
-    - {fileID: 11400000, guid: c5716d3a6d58fe94c9335237ed102a22, type: 2}
+    - {fileID: 11400000, guid: 6aabfe35043501746add2c9433129afd, type: 2}
     - {fileID: 11400000, guid: 1c558ffec7f534dbfb03d1821d59d8ce, type: 2}
     - {fileID: 11400000, guid: cd07afbdad9dc834ebad19070f2c4871, type: 2}

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Sections/GeneralSectionDesktop.asset
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Sections/GeneralSectionDesktop.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2548c6ebc3c846446810452bb5cc2606, type: 3}
+  m_Name: GeneralSectionDesktop
+  m_EditorClassIdentifier: 
+  icon: {fileID: 21300000, guid: 7fa4c0281629e43abbcb190d00fe187a, type: 3}
+  text: General
+  menuButtonPrefab: {fileID: 2470334045984490575, guid: 829d414daa3047541a35abc7d88a1fe5,
+    type: 3}
+  sectionPrefab: {fileID: 5813236629143711783, guid: eb979bec9ddc8d04291cbfd7ff64b626,
+    type: 3}
+  sectionController: {fileID: 11400000, guid: cac7ad54d7c04464a868e7768f9cb004, type: 2}
+  widgets:
+    array:
+    - {fileID: 11400000, guid: fb52c92c6addf994d8c959e16fb2de67, type: 2}
+    - {fileID: 11400000, guid: 3ec66021efcde42129ebf9d7d87edeb4, type: 2}

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Sections/GeneralSectionDesktop.asset.meta
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Sections/GeneralSectionDesktop.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6aabfe35043501746add2c9433129afd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3ccae9e4d9011e4da0803905f169221, type: 3}
+  m_Name: GeneralWidgetDesktop
+  m_EditorClassIdentifier: 
+  title: General
+  widgetPrefab: {fileID: 5794240731996032819, guid: cc8cedcaa38f2424b9f20b88b673f8a9,
+    type: 3}
+  widgetController: {fileID: 11400000, guid: 58b3a5282c16beb42a91390cf2ddfc85, type: 2}
+  controlColumns:
+    array:
+    - controls:
+        array:
+        - {fileID: 11400000, guid: 83813f0a3b25180468ace5f2297b7a3e, type: 2}
+        - {fileID: 11400000, guid: ab5eaa6801a87654a87e47948716e153, type: 2}
+        - {fileID: 11400000, guid: bb6c50358f2355f4f8245f3974b6db3f, type: 2}
+        - {fileID: 11400000, guid: 891daf979e603094b867bd233e346d3c, type: 2}
+    - controls:
+        array:
+        - {fileID: 11400000, guid: e3ec1619997f2e646a6ca99a92a902f8, type: 2}
+        - {fileID: 11400000, guid: 1ec31801283824f4bb71f46f2af1a7b0, type: 2}
+        - {fileID: 11400000, guid: 0430a240bc6f82c4bbe87804db432668, type: 2}

--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset.meta
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Widgets/GeneralWidgetDesktop.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb52c92c6addf994d8c959e16fb2de67
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

I had to override the settings scriptable objects to allow us to change the load radius easily.

Required for https://github.com/decentraland/unity-renderer/issues/2220

## How to test the changes?

Enter settings (P) max scene load radius should be 4 for now.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
