### PR TITLE
chore: fix ci, avoiding double deploy-release executing, throwing error if the ongo…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,6 @@ references:
     filters:
       branches:
         only: /(.*)/
-      tags:
-        only: /^\d+\.\d+\.\d+(.*)/ # npm tag + latest
 
 commands:
   build-unity-generic:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    concurrency: ci
     if: ${{ github.event.check_run.app.name == 'CircleCI Checks' && github.event.check_run.conclusion == 'success' && github.event.check_run.name == 'build-deploy' }}
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +29,27 @@ jobs:
           echo ${VERSION}
           echo "##[set-output name=number;]$(echo ${VERSION})"
         id: set_version
+      - name: Check last commit release
+        shell: bash
+        run: |
+          # Get current commit hash
+          LARGE_COMMIT_HASH=${{ github.sha }}
+          NEW_COMMIT_HASH=${LARGE_COMMIT_HASH::7}
+
+          # Fetch last version
+          LAST_VERSION=$(curl https://api.github.com/repos/decentraland/explorer-desktop/releases/latest --silent | jq '.name' -r)
+          echo ${LAST_VERSION}
+
+          # Get the commit from the last 7 characters of the version
+          LAST_COMMIT_HASH=$(echo -n "${LAST_VERSION}" | tail -c 7)
+
+          # Compare and throw error if are equal
+          echo "Last hash: ${LAST_COMMIT_HASH}"
+          echo "New hash: ${NEW_COMMIT_HASH}"
+          if [ "${NEW_COMMIT_HASH}" == "${LAST_COMMIT_HASH}" ]; then
+            echo "Error: You can't execute another release with the same commit hash that the last one"
+            exit 1
+          fi
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
…ing release has the same commit hash than the last one, and don't compile circleci on tags

This is being tested in https://github.com/kuruk-mm/circleci-gh

After merging this PR, we can activate GitHub Actions.