### PR TITLE
fix: Remove unused prefabs and references (Desktop side)

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Components/Video/Tests/VideoComponenteDesktopShould.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Components/Video/Tests/VideoComponenteDesktopShould.cs
@@ -46,7 +46,6 @@ public class VideoComponenteDesktopShould : IntegrationTestSuite
         yield return base.SetUp();
         scene = TestUtils.CreateTestScene();
         CommonScriptableObjects.rendererState.Set(true);
-        MainSceneFactory.CreateSettingsController();
     }
     
     [UnityTest]


### PR DESCRIPTION
## What does this PR change?
Remove unused prefabs and references.

- [x] Remove call to `MainSceneFactory.CreateSettingsController()` that no longer exists in the `unity-renderer` project (https://github.com/decentraland/unity-renderer/pull/2316)

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
