### PR TITLE
chore: texture size increased for desktop client

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/MainDesktop/MainDesktop.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using DCL.SettingsCommon;
+using DCL.Configuration;
 using DCL.Components;
 using MainScripts.DCL.Controllers.HUD.Preloading;
 using MainScripts.DCL.Controllers.LoadingFlow;
@@ -36,6 +37,13 @@ namespace DCL
             DataStore.i.performance.maxDownloads.Set(50);
             Texture.allowThreadedTextureCreation = true;
             SetupScreenResolution();
+        }
+        
+        protected override void InitializeDataStore()
+        {
+            DataStore.i.textureConfig.gltfMaxSize.Set(TextureCompressionSettings.GLTF_TEX_MAX_SIZE_DESKTOP);
+            DataStore.i.textureConfig.generalMaxSize.Set(TextureCompressionSettings.GENERAL_TEX_MAX_SIZE_DESKTOP);
+            DataStore.i.avatarConfig.useHologramAvatar.Set(true);
         }
 
         protected override void InitializeCommunication()


### PR DESCRIPTION
## What does this PR change?

This PR increases texture size cap for desktop client for both GLTF and other textures to improve quality of rendering in the desktop client.

...

## How to test the changes?

Play desktop client and check if the quality got better / rendering work well. To test this you need to make sure that the desktop client is built with the usage of unity-renderer repo with this PR included into it: https://github.com/decentraland/unity-renderer/pull/2922