### PR TITLE
Fix: forced the load radius to a minimum of 2

### DIFF
--- a/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset
+++ b/unity-renderer-desktop/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUDDesktop/Configs/ScenesLoadRadiusControlConfigurationDesktop.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   flagsThatDeactivateMe: []
   flagsThatOverrideMe: []
   isBeta: 0
-  sliderMinValue: 1
+  sliderMinValue: 2
   sliderMaxValue: 4
   storeValueAsNormalized: 0
   wholeNumbers: 1


### PR DESCRIPTION
## What does this PR change?

This PR changes the minimum value, of scene loading radius option, to 2.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
At very least add the specific URL from which to test the build and add to it any param you think it would be needed.
-->

1. Go to: https://renderer-artifacts.decentraland.org/desktop/index.html?dcl://DESKTOP-BRANCH={branch_name}
2. Open the settings menu and check if the minimum loading radius is 2.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
